### PR TITLE
Improvements to run using published container image

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,6 +18,12 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: get gen-tz.py
+        run: curl --output /tmp/gen-tz.py https://raw.githubusercontent.com/nayarsystems/posix_tz_db/4b9caa3066434b015a99cadb74050fd46b7cc12b/gen-tz.py
+
+      - name: generate tz.json
+        run: python3 /tmp/gen-tz.py --json > tz.json
+
       - name: login to ghcr.io
         uses: docker/login-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,6 @@ cython_debug/
 gen-tz.py
 static/
 tz.json
-user_config.json
-user_multinet.json
-user_nvs.json
+storage/user_config.json
+storage/user_multinet.json
+storage/user_nvs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ COPY . .
 
 EXPOSE 8501
 EXPOSE 8502
+
+CMD /app/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ You will need to (one-time) configure, build, and flash Willow from the ```featu
 ./utils.sh flash-dist
 ```
 
-### WAS Installation
+### Running WAS
+
+```
+docker run --detach --env=OTA_URL="http://my_was_host:8502/static/ota.bin" --name=willow-application-server --pull=always --network=host --restart=unless-stopped --volume=was-storage:/app/storage ghcr.io/toverainc/willow-application-server:main
+```
+
+### Building WAS
 ```
 git clone https://github.com/toverainc/willow-application-server.git && cd willow-application-server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+volumes:
+  was-storage:
 services:
   was:
     restart: unless-stopped
@@ -11,3 +13,4 @@ services:
       - ${LISTEN_IP}:${API_LISTEN_PORT}:8502
     volumes:
       - ./:/app
+      - was-storage:/app/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,3 @@ services:
       - ${LISTEN_IP}:${API_LISTEN_PORT}:8502
     volumes:
       - ./:/app
-    command: ./entrypoint.sh

--- a/ui.py
+++ b/ui.py
@@ -282,7 +282,7 @@ with multinet:
             else:
                 if not save_ha:
                     try:
-                        multinet_commands_file = open("user_multinet.json", "r")
+                        multinet_commands_file = open("storage/user_multinet.json", "r")
                         ha_commands = json.load(multinet_commands_file)
                     except Exception:
                         pass
@@ -294,7 +294,7 @@ with multinet:
             st.session_state["ha_commands"] = ha_commands
 
             if save_ha:
-                with open("user_multinet.json", "w") as multinet_commands:
+                with open("storage/user_multinet.json", "w") as multinet_commands:
                     multinet_commands.write(json.dumps(st.session_state["ha_commands"]))
                 multinet_commands.close()
 

--- a/utils.sh
+++ b/utils.sh
@@ -63,7 +63,7 @@ gen-tz() {
 }
 
 shell() {
-    docker run -it -v $WAS_DIR:/app -v $WAS_DIR/cache:/root/.cache "$IMAGE":"$TAG" \
+    docker run -it -v $WAS_DIR:/app -v $WAS_DIR/cache:/root/.cache -v willow-application-server_was-storage:/app/storage "$IMAGE":"$TAG" \
         /usr/bin/env bash
 }
 


### PR DESCRIPTION
We should make it as simple as possible for people to run WAS. Right now, people need to clone a git repo, run multiple commands and create a .env file. With the changes in this PR, people can run the published container image with a single command. A persistent volume to keep the user_*.json files will automatically be created, so settings will survive restarting/updating containers.

Tested with `docker run ..` and `./utils.sh`. To test before merge, use the feature-storage_dir tag:
```
docker run --rm -it --env=OTA_URL="http://my_was_host:8502/static/ota.bin" --network=host --volume=was-storage:/app/storage ghcr.io/toverainc/willow-application-server:feature-storage_dir
```