### PR TITLE
README: use same container name in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ To use a self-built binary for OTA, place it in the the ota/local directory of t
 
 To copy the file to the running container:
 ```
-podman cp build/willow.bin was:/app/storage/ota/local/willow-ota-ESP32_S3_BOX.bin
+podman cp build/willow.bin willow-application-server:/app/storage/ota/local/willow-ota-ESP32_S3_BOX.bin
 ```


### PR DESCRIPTION
The command to start the WAS container uses willow-application-server as container name. Let's be consistent and use the same in the command to copy the Willow binary to the container to avoid confusion.