### PR TITLE
treewide: fix double JSON serialization

### DIFF
--- a/api.py
+++ b/api.py
@@ -168,6 +168,7 @@ async def post_config(request, apply=False):
             log.error(f"failed to apply config to {data['hostname']} ({e})")
             return "Error"
     else:
+        data = json.dumps(data)
         save_json_to_file(STORAGE_USER_CONFIG, data)
         msg = build_msg(data, "config")
         log.info(str(msg))
@@ -191,6 +192,7 @@ async def post_nvs(request, apply=False):
             log.error(f"failed to apply config to {data['hostname']} ({e})")
             return "Error"
     else:
+        data = json.dumps(data)
         save_json_to_file(STORAGE_USER_NVS, data)
         msg = build_msg(data, "nvs")
         log.info(str(msg))

--- a/ui.py
+++ b/ui.py
@@ -179,8 +179,7 @@ with configuration:
         nvs_apply = st.button("Save and Apply", key="btn_nvs")
         if nvs_apply:
             if validate_nvs(nvs):
-                json_object = json.dumps(nvs, indent=2)
-                post_nvs(json_object, True)
+                post_nvs(nvs, True)
                 st.write("NVS values saved")
                 st.json(nvs)
                 st.experimental_rerun()
@@ -188,8 +187,7 @@ with configuration:
         nvs_save = st.button("Save", key="btn_nvs_save")
         if nvs_save:
             if validate_nvs(nvs):
-                json_object = json.dumps(nvs, indent=2)
-                post_nvs(json_object, False)
+                post_nvs(nvs, False)
                 st.write("NVS values saved")
                 st.json(nvs)
                 st.experimental_rerun()
@@ -316,8 +314,7 @@ with configuration:
         config_save = st.button("Save")
         if config_save:
             if validate_config(config):
-                json_object = json.dumps(config, indent=2)
-                post_config(json_object, False)
+                post_config(config, False)
                 st.write("Configuration Saved:")
                 st.json(config)
                 st.experimental_rerun()
@@ -325,8 +322,7 @@ with configuration:
         config_apply = st.button("Save and Apply")
         if config_apply:
             if validate_config(config):
-                json_object = json.dumps(config, indent=2)
-                post_config(json_object, True)
+                post_config(config, True)
                 st.write("Configuration Saved:")
                 st.json(config)
                 st.experimental_rerun()


### PR DESCRIPTION
When calling the /api/nvs/save API via curl, we were seeing the following stack trace:

willow-application-server-was-1  |   File "/app/api.py", line 345, in save_nvs
willow-application-server-was-1  |     await post_nvs(request, False)
willow-application-server-was-1  |   File "/app/api.py", line 202, in post_nvs
willow-application-server-was-1  |     save_json_to_file(STORAGE_USER_NVS, data)
willow-application-server-was-1  |   File "/app/api.py", line 212, in save_json_to_file
willow-application-server-was-1  |     config_file.write(content)
willow-application-server-was-1  | TypeError: write() argument must be str, not dict

This is because we're JSON serializing the json argument to shared.post_nvs(). In shared.post_nvs(), we're passing the json argument to reequests.post() as a json named argument. This will serialize it again. It is then deserialized by request.json() in api.post_nvs(). We then try to write it to a file, which works fine when calling the /api/nvs/save via the UI, as deserializing once will result in a string.

However, when we call the /api/nvs/save via curl, deserializing results in a python dict, which cannot be written to a file.

Do not serialize the data before passing it to shared.post_nvs() to fix this. We will then always end up with data being a dict in api.post_nvs(), so we need to serialize it before writing it to a file.

The same problem exists in post_config(), so fix it there also.