### PR TITLE
requirements: bump FastAPI to 0.103.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 altair==5.0.1
-anyio==3.7.0
+anyio==3.7.1
 attrs==23.1.0
 blinker==1.6.2
 cachetools==5.3.1
@@ -7,7 +7,7 @@ certifi==2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 decorator==5.1.1
-fastapi==0.97.0
+fastapi==0.103.1
 gitdb==4.0.10
 GitPython==3.1.33
 h11==0.14.0


### PR DESCRIPTION
This requires AnyIO >= 3.7.1 <= 4.0.0, so bump AnyIO to 3.7.1.

With v0.100.2, Pydantic v2 support was introduced. Its core was re-written in Rust and should improve performance.