### PR TITLE
ui: select latest release by default

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -136,7 +136,12 @@ with clients:
                 if releases[release].get(row['hw_type']) is None:
                     device_releases.pop(release)
 
-            version.selectbox("Select release to flash", device_releases, key=f"sb_ota_{idx}")
+            idx_latest = 0
+            for rel_idx, release in enumerate(list(device_releases)):
+                if release == latest_release:
+                    idx_latest = rel_idx
+
+            version.selectbox("Select release to flash", device_releases, key=f"sb_ota_{idx}", index=idx_latest)
             version.button(key=f"btn_ota_{idx}", kwargs=dict(hostname=row['hostname'],
                            info=releases[st.session_state[f"sb_ota_{idx}"]][row['hw_type']],
                            version=st.session_state[f"sb_ota_{idx}"]), label="OTA", on_click=ota, type="primary")


### PR DESCRIPTION
Ideally we want to only show non-pre releases by default, and in that case we wouldn't have to do this, but as we don't have a final release right now, let's make sure we select the release marked as latest Github by default in the OTA dropdown.