### PR TITLE
Increase final response timeout to 30 seconds for REST endpoint

### DIFF
--- a/command_endpoints/rest.py
+++ b/command_endpoints/rest.py
@@ -85,7 +85,7 @@ class RestEndpoint(CommandEndpoint):
             else:
                 raise CommandEndpointConfigException("invalid REST auth type")
 
-            return request("POST", self.url, auth=basic, data=data, headers=headers, json=jsondata)
+            return request("POST", self.url, auth=basic, data=data, headers=headers, json=jsondata, timeout=(1, 30))
 
         except Exception as e:
             raise CommandEndpointRuntimeException(e)


### PR DESCRIPTION
Python requests (by default) has no timeout. This can cause WAS to hang indefinitely waiting for a REST response. Set a connect timeout of 1s which will speedily address connection failures for blatantly misconfigured REST endpoints. Also set final response timeout to 30 seconds which is still long but plenty of time for an LLM, etc to respond.