### PR TITLE
api: fix exceptions in post_config, post_nvs

### DIFF
--- a/api.py
+++ b/api.py
@@ -370,7 +370,7 @@ async def post_config(request, apply=False):
             await ws.send_text(msg)
             return "Success"
         except Exception as e:
-            log.error(f"Failed to apply config to {data['hostname']} ({e})")
+            log.error(f"Failed to apply config to {hostname} ({e})")
             return "Error"
     else:
         data = json.dumps(data)
@@ -400,7 +400,7 @@ async def post_nvs(request, apply=False):
             await ws.send_text(msg)
             return "Success"
         except Exception as e:
-            log.error(f"Failed to apply config to {data['hostname']} ({e})")
+            log.error(f"Failed to apply config to {hostname} ({e})")
             return "Error"
     else:
         data = json.dumps(data)


### PR DESCRIPTION
We first check if data contains hostname, but then we overwrite data with get_nvs which does not contain hostname, so if we hit an exception later, the call to log.error causes another exception.

As we're copying data['hostname'] to hostname before overriding data, we should print the hostname variable instead.

This avoids the following exception during handling of another exception:

```
[2023-10-25T13:52:39] INFO:     10.0.2.100:45554 - 'POST /api/config?type=nvs&apply=1 HTTP/1.1' 500 Internal Server Error
[2023-10-25T13:52:39] ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/app/api.py", line 400, in post_nvs
    await ws.send_text(msg)
  File "/usr/local/lib/python3.12/site-packages/starlette/websockets.py", line 163, in send_text
    await self.send({"type": "websocket.send", "text": data})
  File "/usr/local/lib/python3.12/site-packages/starlette/websockets.py", line 85, in send
    await self._send(message)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 65, in sender
    await send(message)
  File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/websockets/websockets_impl.py", line 338, in asgi_send
    raise RuntimeError(msg % message_type)
RuntimeError: Unexpected ASGI message 'websocket.send', after sending 'websocket.close'.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 426, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/applications.py", line 292, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/cors.py", line 91, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/cors.py", line 146, in simple_response
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/usr/local/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/usr/local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "/usr/local/lib/python3.12/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 273, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/routing.py", line 190, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/api.py", line 675, in api_post_config
    await post_nvs(request, config.apply)
  File "/app/api.py", line 403, in post_nvs
    log.error(f"Failed to apply config to {data['hostname']} ({e})")
                                           ~~~~^^^^^^^^^^^^
KeyError: 'hostname'
```