### PR TITLE
container: use uvloop wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Install gcc temporarily until wheels for httptools on Python 3.12 are available
-RUN apt-get update && apt-get install -y gcc libmagic1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y gcc libc6-dev libmagic1 && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache pip install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,9 @@ WORKDIR /app
 COPY requirements.txt .
 
 # Install gcc temporarily until wheels for httptools on Python 3.12 are available
-RUN apt-get update && apt-get install -y gcc libmagic1
+RUN apt-get update && apt-get install -y gcc libmagic1 && rm -rf /var/lib/apt/lists/*
 
 RUN --mount=type=cache,target=/root/.cache pip install -r requirements.txt
-
-# Install deps to build uvloop until wheels are released
-RUN apt-get install -y automake git libtool-bin libuv1-dev make && rm -rf /var/lib/apt/lists/*
-
-RUN --mount=type=cache,target=/root/.cache pip install setuptools
-
-RUN --mount=type=cache,target=/root/.cache pip install 'uvloop@git+https://github.com/MagicStack/uvloop.git@9f82bd7'
 
 COPY . .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,6 @@ typing_extensions==4.8.0
 ujson==5.8.0
 urllib3==2.0.6
 uvicorn==0.23.2
+uvloop==0.19.0
 watchfiles==0.20.0
 websockets==11.0.3


### PR DESCRIPTION
Wheels for uvloop are now available, so let's add uvloop to requirements.txt to avoid it being built.

This greatly reduces the container image build time.