### PR TITLE
command_endpoints: fix cb_disconnect in MqttEndpoint

### DIFF
--- a/app/internal/command_endpoints/mqtt.py
+++ b/app/internal/command_endpoints/mqtt.py
@@ -91,7 +91,7 @@ class MqttEndpoint(CommandEndpoint):
         self.log.info("MQTT connected")
         client.subscribe(self.config.topic)
 
-    def cb_disconnect(client, userdata, rc):
+    def cb_disconnect(self, client, userdata, rc):
         self.connected = False
         self.log.info("MQTT disconnected")
 


### PR DESCRIPTION
The cb_disconnect function lacks the self argument.

Silences the following flake8 errors:

app/internal/command_endpoints/mqtt.py:95:9: F821 undefined name 'self'
app/internal/command_endpoints/mqtt.py:96:9: F821 undefined name 'self'

Fixes: 571cf763b0db ("command_endpoints: add connected boolean to MqttEndpoint")