### PR TITLE
command_endpoints: sanitize result

### DIFF
--- a/app/internal/command_endpoints/__init__.py
+++ b/app/internal/command_endpoints/__init__.py
@@ -30,9 +30,16 @@ class CommandEndpointResult(BaseModel):
     ok: bool = False
     speech: str = "Error!"
 
+    def sanitize(self):
+        self.speech = self.speech.replace("\n", " ").replace("\r", " ").lstrip()
+
 
 class CommandEndpointResponse(BaseModel):
     result: CommandEndpointResult = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.result.sanitize()
 
 
 class CommandEndpoint():


### PR DESCRIPTION
A command endpoint that inserts newlines in the speech result causes the result to be printed outside of the display. We do not want to deal with this in the Willow C code, and as we will eventually make WAS command mode the default and rip out endpoint support from Willow, we can simply do this in WAS.

As we're using a pydantic model for the command endpoint result, we can easily do this with a sanitize function in the CommandEndpointResult model, and call this when we initialize the CommandEndpointResponse. We can't do it when we initialize the CommandEndpointResult, as we sometimes change the speech attribute after init.