### PR TITLE
requirements: bump urllib3 to 2.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ sniffio==1.3.0
 starlette==0.27.0
 typing_extensions==4.8.0
 ujson==5.8.0
-urllib3==2.0.6
+urllib3==2.0.7
 uvicorn==0.23.2
 uvloop==0.19.0
 watchfiles==0.20.0


### PR DESCRIPTION
Fixes CVE-2023-45803 (moderate).