### PR TITLE
default_config: set audio response to TTS by default

### DIFF
--- a/default_config.json
+++ b/default_config.json
@@ -1,7 +1,7 @@
 {
   "aec": true,
   "audio_codec": "PCM",
-  "audio_response_type": "None",
+  "audio_response_type": "TTS",
   "bss": false,
   "command_endpoint": "Home Assistant",
   "display_timeout": 10,


### PR DESCRIPTION
We've had several reports of TTS not working. This was often because the user did not enable TTS audio responses. Let's make it the default to avoid more such reports in the future.