### PR TITLE
routers.release: fix api_post_release path

### DIFF
--- a/app/routers/release.py
+++ b/app/routers/release.py
@@ -54,7 +54,7 @@ class PostRelease(BaseModel):
     action: Literal['cache', 'delete'] = Field(Query(..., description='Release Cache Control'))
 
 
-@router.post("/api/release")
+@router.post("/release")
 async def api_post_release(request: Request, release: PostRelease = Depends()):
     log.debug('API POST RELEASE: Request')
     if release.action == "cache":


### PR DESCRIPTION
The release API router uses the /api prefix so we must not add it in routes.

Fixes: eedfa7c3624e ("app: move POST /api/release to app.routers.release")