### PR TITLE
Dockerfile: copy requirements.txt after apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.12.0-slim-bookworm
 
 WORKDIR /app
 
-COPY requirements.txt .
-
 # Install gcc temporarily until wheels for httptools on Python 3.12 are available
 RUN apt-get update && apt-get install --no-install-recommends -y gcc libc6-dev libmagic1 && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
 
 RUN --mount=type=cache,target=/root/.cache pip install -r requirements.txt
 


### PR DESCRIPTION
This way, modifications to requirements.txt will not trigger apt-get, slightly reducing wait times during development when adding or updating requirements.