### PR TITLE
wake: increase WakeSession timeout

### DIFF
--- a/app/internal/wake.py
+++ b/app/internal/wake.py
@@ -27,7 +27,7 @@ class WakeSession:
         log.debug(f"WakeSession {self.id} adding event {event}")
         self.events.append(event)
 
-    async def cleanup(self, timeout=200):
+    async def cleanup(self, timeout=400):
         await asyncio.sleep(timeout / 1000)
         max_volume = -1000.0
         winner = None


### PR DESCRIPTION
With a WakeSession timeout of 200ms, some people frequently experience double wakes. Testing has shown that 400ms greatly reduces those double wakes, and does not introduce other issues.

Let's make 400ms the default.