### PR TITLE
CI: don't push container on pull request

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -75,6 +75,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'push' }}
           labels: ${{ steps.metadata.outputs.labels }}
           tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
The maximum access for pull requests from public forked repositories for the packages scope is read, so we can not push a container to GHCR in a workflow triggered by a pull request from a fork. Fortunately this is not an issue here, as we just want CI to test if building WAS fails or not. The container image will be pushed once the PR is merged in the base branch.

Only push the container image for push events so pull requests from forks will not fail with 403.