### PR TITLE
CI: don't push container image for dependabot updates

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -75,6 +75,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
           labels: ${{ steps.metadata.outputs.labels }}
           tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
Dependabot updates create a local branch and trigger a push event. Because of this, we're still trying to push the container image to GHCR. As Dependabot push events are treated as they come from a fork, they receive a read-only GITHUB_TOKEN and thus are not able to push the container image and the workflow still fails with 403.

Skip push when github.actor is 'dependabot[bot]' to avoid this.