### PR TITLE
Dockerfile: bump base container to 3.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.0-slim-bookworm
+FROM python:3.12.9-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
This is the current most recent version in the 3.12 release.