### PR TITLE
Docker: use sh in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 
 # Log level - acceptable values are debug, info, warning, error, critical. Suggest info or debug.


### PR DESCRIPTION
Alpine doesn't have bash installed by default. Switch to sh to fix the following error during startup:

env: can't execute 'bash': No such file or directory

Fixes: 4b49d31cbad9 ("Docker: use Alpine base container")