### PR TITLE
requirements: bump pydantic to 2.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-annotated-types==0.5.0
+annotated-types==0.7.0
 anyio==3.7.1
 certifi==2023.7.22
 charset-normalizer==3.2.0
@@ -18,10 +18,10 @@ MarkupSafe==2.1.3
 num2words==0.5.12
 orjson==3.9.15
 paho-mqtt==1.6.1
-pydantic==2.3.0
+pydantic==2.11.1
 pydantic-extra-types==2.1.0
 pydantic-settings==2.0.3
-pydantic_core==2.6.3
+pydantic_core==2.33.0
 pytest==8.3.4
 python-dotenv==1.0.0
 python-magic==0.4.27
@@ -30,7 +30,7 @@ PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
 starlette==0.27.0
-typing_extensions==4.8.0
+typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2
 uvicorn==0.23.2


### PR DESCRIPTION
This is the current most recent version of pydantic.

Also bump dependencies that are causing conflicts.

Fixes CVE-2024-3772 (moderate).

Closes: #91