### PR TITLE
Bump FastAPI to 0.115.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.112.4
+fastapi==0.114.2
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.109.2
+fastapi==0.110.3
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -29,7 +29,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.36.3
+starlette==0.37.2
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.103.2
+fastapi==0.107.0
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -29,7 +29,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.27.0
+starlette==0.28.0
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.114.2
+fastapi==0.115.12
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -28,7 +28,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.38.6
+starlette==0.46.1
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.107.0
+fastapi==0.108.0
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -29,7 +29,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.28.0
+starlette==0.32.0
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.108.0
+fastapi==0.109.2
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -29,7 +29,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.32.0
+starlette==0.36.3
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.110.3
+fastapi==0.111.1
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -16,7 +16,6 @@ itsdangerous==2.1.2
 Jinja2==3.1.6
 MarkupSafe==2.1.3
 num2words==0.5.12
-orjson==3.9.15
 paho-mqtt==1.6.1
 pydantic==2.11.1
 pydantic-extra-types==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
-fastapi==0.111.1
+fastapi==0.112.4
 h11==0.14.0
 httpcore==0.18.0
 httptools==0.6.0
@@ -28,7 +28,7 @@ python-multipart==0.0.18
 PyYAML==6.0.1
 requests==2.32.2
 sniffio==1.3.0
-starlette==0.37.2
+starlette==0.38.6
 typing_extensions==4.13.0
 ujson==5.8.0
 urllib3==2.2.2


### PR DESCRIPTION
As FastAPI is the core of Willow Application Server, this bump has been done in some incremental steps. This makes it easier to bisect potential issues. Each step has received some basic testing.