### PR TITLE
command_endpoints: handle missing speech responses from HomeAssistant

### DIFF
--- a/app/internal/command_endpoints/ha_rest.py
+++ b/app/internal/command_endpoints/ha_rest.py
@@ -24,8 +24,10 @@ class HomeAssistantRestEndpoint(RestEndpoint):
         return f"{ha_url_scheme}{self.host}:{self.port}/api/conversation/process"
 
     def get_speech(self, data):
-        speech = data["response"]["speech"]["plain"]["speech"]
-        return speech
+        if 'plain' in data["response"]["speech"]:
+            return data["response"]["speech"]["plain"]["speech"]
+        else:
+            return ""
 
     def parse_response(self, response):
         res = CommandEndpointResult()

--- a/app/internal/command_endpoints/ha_ws.py
+++ b/app/internal/command_endpoints/ha_ws.py
@@ -81,7 +81,12 @@ class HomeAssistantWebSocketEndpoint(CommandEndpoint):
                     response_type = msg["event"]["data"]["intent_output"]["response"]["response_type"]
                     if response_type == "action_done":
                         out.ok = True
-                    out.speech = msg["event"]["data"]["intent_output"]["response"]["speech"]["plain"]["speech"]
+                    response = msg["event"]["data"]["intent_output"]["response"]
+                    # Not all intents return speech (e.g. HassNeverMind)
+                    if 'plain' in response["speech"]:
+                        out.speech = response["speech"]["plain"]["speech"]
+                    else:
+                        out.speech = ""
                     command_endpoint_response = CommandEndpointResponse(result=out)
                     self.log.debug(f"sending {command_endpoint_response} to {ws}")
                     asyncio.ensure_future(ws.send_text(command_endpoint_response.model_dump_json()))


### PR DESCRIPTION
It appears certain intents (e.g. HassNeverMind (en) ) return a speech object that does not contain a plain text element.

This resulted in errors in the log such as:

as-1  | 2025-04-08 19:56:31 INFO     WAS Home Assistant WebSocket Endpoint: exception occurred: 'plain'

The Home Assistant documentation also suggests that returning SSML is a possibility too (https://developers.home-assistant.io/docs/intent_conversation_api#speech)

This fix means if there is no plain speech element returned, the code will now return an empty string to Willow, and will no longer error.