### PR TITLE
requirements: bump httpcore to 1.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,10 @@ dnspython==2.6.1
 docopt==0.6.2
 email-validator==2.0.0.post2
 fastapi==0.115.12
-h11==0.14.0
-httpcore==0.18.0
+h11==0.16.0
+httpcore==1.0.9
 httptools==0.6.0
-httpx==0.25.0
+httpx==0.28.1
 idna==3.7
 itsdangerous==2.1.2
 Jinja2==3.1.6


### PR DESCRIPTION
This requires h11 and httpx to be bumped. Bump both of them to the current most recent version.

Closes: #100