### PR TITLE
treewide: remove gen-tz.py script

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -25,12 +25,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: get gen-tz.py
-        run: curl --output /tmp/gen-tz.py https://raw.githubusercontent.com/nayarsystems/posix_tz_db/4b9caa3066434b015a99cadb74050fd46b7cc12b/gen-tz.py
-
-      - name: generate tz.json
-        run: python3 /tmp/gen-tz.py --json > tz.json
-
       - name: configure QEMU
         uses: docker/setup-qemu-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -160,9 +160,7 @@ cython_debug/
 #.idea/
 
 # WAS
-gen-tz.py
 static/
-tz.json
 storage
 
 # Web UI working directory and others

--- a/app/internal/was.py
+++ b/app/internal/was.py
@@ -267,17 +267,6 @@ def get_releases_willow():
     return releases
 
 
-def get_tz():
-    try:
-        with open("tz.json", "r") as config_file:
-            tz = json.load(config_file)
-        config_file.close()
-    except Exception:
-        tz = {}
-
-    return tz
-
-
 def get_tz_config(refresh=False):
     if refresh:
         tz = requests.get(URL_WILLOW_TZ).json()

--- a/utils.sh
+++ b/utils.sh
@@ -97,11 +97,6 @@ build-web-ui() {
     ./utils.sh build
 }
 
-gen-tz() {
-    curl --output misc/gen-tz.py https://raw.githubusercontent.com/nayarsystems/posix_tz_db/master/gen-tz.py
-    python3 misc/gen-tz.py --json > tz.json
-}
-
 shell() {
     docker run -it -v $WAS_DIR:/app -v $WAS_DIR/cache:/root/.cache -v willow-application-server_was-storage:/app/storage "$IMAGE":"$TAG" \
         /usr/bin/env bash
@@ -110,7 +105,6 @@ shell() {
 case $1 in
 
 build-docker|build)
-    gen-tz
     build-docker
 ;;
 
@@ -120,10 +114,6 @@ build-web-ui)
 
 freeze-requirements)
     freeze_requirements
-;;
-
-gen-tz)
-    gen-tz
 ;;
 
 start|run|up)


### PR DESCRIPTION
WAS fetches timezone info from the Willow CF Worker at startup. The tz.json file generated by the gen-tz.py script is not used anymore.