### PR TITLE
HA WS endpoint: get/send device_id from HA integration

### DIFF
--- a/app/internal/command_endpoints/ha_rest.py
+++ b/app/internal/command_endpoints/ha_rest.py
@@ -38,6 +38,6 @@ class HomeAssistantRestEndpoint(RestEndpoint):
         command_endpoint_response = CommandEndpointResponse(result=res)
         return command_endpoint_response.model_dump_json()
 
-    def send(self, data=None, jsondata=None, ws=None):
+    def send(self, data=None, jsondata=None, ws=None, client=None):
         out = {'text': jsondata["text"], 'language': jsondata["language"]}
         return super().send(jsondata=out)

--- a/app/internal/command_endpoints/ha_ws.py
+++ b/app/internal/command_endpoints/ha_ws.py
@@ -21,6 +21,7 @@ class HomeAssistantWebSocketEndpoint(CommandEndpoint):
     connmap = {}
 
     def __init__(self, app, host, port, tls, token):
+
         self.app = app
         self.host = host
         self.port = port
@@ -105,7 +106,7 @@ class HomeAssistantWebSocketEndpoint(CommandEndpoint):
     def next_id(self):
         return int(time.monotonic_ns())
 
-    def send(self, jsondata, ws):
+    def send(self, jsondata, ws, client=None):
         id = self.next_id()
 
         if id not in self.connmap:

--- a/app/internal/command_endpoints/mqtt.py
+++ b/app/internal/command_endpoints/mqtt.py
@@ -110,7 +110,7 @@ class MqttEndpoint(CommandEndpoint):
         command_endpoint_response = CommandEndpointResponse(result=res)
         return command_endpoint_response.model_dump_json()
 
-    def send(self, data=None, jsondata=None, ws=None):
+    def send(self, data=None, jsondata=None, ws=None, client=None):
         if not self.connected:
             raise CommandEndpointRuntimeException(f"{self.name} not connected")
         try:

--- a/app/internal/command_endpoints/openhab.py
+++ b/app/internal/command_endpoints/openhab.py
@@ -8,5 +8,5 @@ class OpenhabEndpoint(RestEndpoint):
         self.config = RestConfig(auth_type=RestAuthType.BASIC, auth_user=token)
         self.url = f"{url}/rest/voice/interpreters"
 
-    def send(self, jsondata=None, ws=None):
+    def send(self, jsondata=None, ws=None, client=None):
         return super().send(data=jsondata["text"])

--- a/app/internal/command_endpoints/rest.py
+++ b/app/internal/command_endpoints/rest.py
@@ -68,7 +68,7 @@ class RestEndpoint(CommandEndpoint):
         command_endpoint_response = CommandEndpointResponse(result=res)
         return command_endpoint_response.model_dump_json()
 
-    def send(self, data=None, jsondata=None, ws=None):
+    def send(self, data=None, jsondata=None, ws=None, client=None):
         try:
             basic = None
             headers = {}

--- a/app/main.py
+++ b/app/main.py
@@ -221,7 +221,7 @@ async def websocket_endpoint(
                     if app.command_endpoint is not None:
                         log.debug(f"Sending {msg['data']} to {app.command_endpoint.name}")
                         try:
-                            resp = app.command_endpoint.send(jsondata=msg["data"], ws=websocket)
+                            resp = app.command_endpoint.send(jsondata=msg["data"], ws=websocket, client=client)
                             if resp is not None:
                                 resp = app.command_endpoint.parse_response(resp)
                                 log.debug(f"Got response {resp} from endpoint")


### PR DESCRIPTION
Get Willow device_id from the Home Assistant integration (https://github.com/ciaranj/ha_willow_integration) and add it when sending a command to Home Assistant over WebSocket. With this, Willow supports area awareness!